### PR TITLE
Read from osu!.db

### DIFF
--- a/osu!Sync/OsuReader.vb
+++ b/osu!Sync/OsuReader.vb
@@ -1,0 +1,18 @@
+﻿Imports System.IO
+
+Public Class OsuReader
+    Inherits BinaryReader
+
+    Sub New(s As Stream)
+        MyBase.New(s)
+    End Sub    Public Overrides Function ReadString() As String
+        Dim tag As Byte = ReadByte()
+        If tag = 0 Then Return Nothing
+        If tag = &HB Then Return MyBase.ReadString()
+        Throw New IOException("Invalid string tag")
+    End Function
+
+    Public Function ReadDate() As DateTime
+        Return New DateTime(ReadInt64())
+    End Function
+End Class

--- a/osu!Sync/osu!Sync.vbproj
+++ b/osu!Sync/osu!Sync.vbproj
@@ -118,6 +118,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Global_Var.vb" />
+    <Compile Include="OsuReader.vb" />
     <Compile Include="Window_Settings.xaml.vb">
       <DependentUpon>Window_Settings.xaml</DependentUpon>
     </Compile>

--- a/osu!Sync/osu!Sync.vbproj
+++ b/osu!Sync/osu!Sync.vbproj
@@ -290,6 +290,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"C:\Users\Kevin\Documents\Visual Studio 2013\Tools\InsertIcons.exe" "$(TargetPath)" "$(ProjectDir)Icons"</PostBuildEvent>
+    <PostBuildEvent>"$(DevEnvDir)..\Tools\InsertIcons.exe" "$(TargetPath)" "$(ProjectDir)Icons"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reading from the database osu! uses to keep track of it's installed beatmaps is much quicker and more reliable than trying to look for IDs in the Songs folder.
osu!.db format: https://osu.ppy.sh/wiki/Db_(file_format)#osu.21.db

Also changed the post build event to point to "$(DevEnvDir)..\Tools\InsertIcons.exe" instead of the hardcoded path.

I'm much more comfortable with c# so sorry in advance for any unreadable code.
